### PR TITLE
Manually build and push docker image

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -58,11 +58,13 @@ runs:
 
     ###### Publish Docker Image ######
 
-    - name: Build and push
-      uses: docker/build-push-action@v2
-      with:
-        push: true
-        tags: ${{ steps.variables.outputs.build_image }}
+    - name: Containerize
+      run: docker build -t ${{ steps.variables.outputs.build_image }} .
+      shell: bash
+
+    - name: Publish
+      run: docker push ${{ steps.variables.outputs.build_image }}
+      shell: bash
 
     ###### Deploy Cloud Run ######
 


### PR DESCRIPTION
## 📑 Description
It was discovered from this [workflow run](https://github.com/dmsi-io/houston-api-docs/runs/5772037833?check_suite_focus=true) that the `docker/build-push-action@v2` GHA checks out the repo and builds from that fresh clone. This is very problematic for repos that need to run a build step prior to the docker build step. 

Because of this, I am reverting back to the manual build and push steps so it will build as-is in the workflow.